### PR TITLE
Set site settings as part of site creation

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -82,7 +82,17 @@
         "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
       ],
       "properties":{
-        "serverFarmId":"[parameters('hostingPlanName')]"
+        "serverFarmId":"[parameters('hostingPlanName')]",
+        "siteConfig": {
+          "webSocketsEnabled": true,
+          "virtualApplications": [
+            {
+              "virtualPath": "/",
+              "physicalPath": "site\\wwwroot\\Server",
+              "preloadEnabled": true
+            }
+          ]
+        }
       },
       "resources":[
         {
@@ -96,26 +106,6 @@
             "RepoUrl":"[parameters('repoURL')]",
             "branch": "[parameters('branch')]",
             "IsManualIntegration":true
-          }
-        },
-        { 
-          "apiVersion": "2014-04-01", 
-          "type": "config", 
-          "name": "web", 
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]",
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'), '/sourcecontrols/web')]"
-          ], 
-          "properties": { 
-            "webSocketsEnabled": true,
-            "virtualApplications": [
-              {
-                "virtualPath": "/",
-                "physicalPath": "site\\wwwroot\\Server",
-                "preloadEnabled": true,
-                "virtualDirectories": null
-              }
-            ]
           }
         }
       ]


### PR DESCRIPTION
This seems to solve the issue, but I see deployment failing with:

```
...
npm ERR! EEXIST, open 'D:\local\AppData\npm-cache\d00d6bc1-adable-stream-1-0-33-package-tgz.lock'
File exists: D:\local\AppData\npm-cache\d00d6bc1-adable-stream-1-0-33-package-tgz.lock
Move it away, and try again. 
```

It then passes on retry. I don't think this is related.